### PR TITLE
Update psmdt.sql

### DIFF
--- a/sqlfiles/psmdt.sql
+++ b/sqlfiles/psmdt.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS `mdt_data` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `cid` VARCHAR(20) DEFAULT NULL,
+  `cid` VARCHAR(20) NOT NULL,
   `information` MEDIUMTEXT DEFAULT NULL,
   `tags` TEXT NOT NULL,
   `gallery` TEXT NOT NULL,


### PR DESCRIPTION
resolves the `PRIMARY KEY must be NOT NULL` error during database initialization by updating the `mdt_data` table schema.

## Pull Request Checklist

- [ x] PR is targeting the `dev` branch
- [ x] I have pulled the latest changes from `dev` and resolved any merge conflicts
- [ x] My code follows the project’s style guidelines
- [ x] I have tested my changes and ensured they work as expected
- [ x] Relevant documentation/comments have been added or updated
- [ ] Any dependent changes have been merged

## Description

This PR fixes a critical error encountered when initializing the database schema on a clean MySQL server, specifically the constraint violation where a Primary Key column was defined as `DEFAULT NULL`.

<!-- Please include a summary of the changes and the purpose of this PR -->
* Changed the `cid` column definition from `VARCHAR(20) DEFAULT NULL` to **`VARCHAR(20) NOT NULL`**.

## Related Issues

<!-- If this PR addresses any issues, please link them here using "Fixes #issue_number" -->

## Testing Steps
1.  Running the SQL file (`psmdt.sql`) on a fresh Ubuntu Server with MySQL 8.0.
2.  Confirming the table `mdt_data` was created successfully without the `PRIMARY KEY must be NOT NULL` error.

<!-- Describe how the changes were tested and how reviewers can verify them -->

## Additional Notes

<!-- Add any other relevant information or context here -->
